### PR TITLE
Heirarchical symbols for bandgapReference

### DIFF
--- a/bandgap_sky130_v1/cascode_amplifier_with_bias-ckt.sch
+++ b/bandgap_sky130_v1/cascode_amplifier_with_bias-ckt.sch
@@ -1,0 +1,196 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {}
+V {}
+S {}
+E {}
+P 4 5 550 -240 640 -240 640 -130 550 -130 550 -240 {}
+T {I/O Pins} 570 -230 0 0 0.3 0.3 {}
+N 110 -310 170 -310 { lab=vg}
+N 170 -340 170 -310 { lab=vg}
+N 150 -340 170 -340 { lab=vg}
+N 170 -340 280 -340 { lab=vg}
+N 110 -390 110 -370 { lab=VDD}
+N 320 -390 320 -370 { lab=VDD}
+N 110 -310 110 -240 { lab=vg}
+N 320 -300 320 -240 { lab=vout}
+N 50 -210 70 -210 { lab=va}
+N 310 -180 320 -180 { lab=Vq}
+N 320 -340 330 -340 { lab=VDD}
+N 330 -370 330 -340 { lab=VDD}
+N 320 -370 330 -370 { lab=VDD}
+N 100 -340 110 -340 { lab=VDD}
+N 100 -370 100 -340 { lab=VDD}
+N 100 -370 110 -370 { lab=VDD}
+N 110 -210 120 -210 { lab=GND}
+N 310 -210 320 -210 { lab=GND}
+N 200 -60 210 -60 { lab=GND}
+N 200 -60 200 -30 { lab=GND}
+N 250 -60 380 -60 { lab=Vx}
+N 420 -60 430 -60 { lab=GND}
+N 380 -90 380 -60 { lab=Vx}
+N 380 -90 420 -90 { lab=Vx}
+N 430 -60 430 -30 { lab=GND}
+N 420 -290 430 -290 { lab=VDD}
+N 430 -320 430 -290 { lab=VDD}
+N 420 -320 430 -320 { lab=VDD}
+N 380 -300 380 -290 { lab=vout}
+N 420 -390 420 -320 { lab=VDD}
+N 110 -390 320 -390 { lab=VDD}
+N 110 -180 120 -180 { lab=Vq}
+N 210 -180 310 -180 { lab=Vq}
+N 200 -30 430 -30 { lab=GND}
+N 120 -180 210 -180 { lab=Vq}
+N 320 -310 320 -300 { lab=vout}
+N 320 -300 380 -300 { lab=vout}
+N 320 -390 420 -390 { lab=VDD}
+N 120 -210 310 -210 { lab=GND}
+N 420 -260 420 -140 {
+lab=Vx}
+N 420 -140 420 -90 {
+lab=Vx}
+N 210 -110 210 -90 {
+lab=Vq}
+N 210 -180 210 -110 {
+lab=Vq}
+N 360 -210 370 -210 {
+lab=vb}
+N 380 -300 520 -300 {
+lab=vout}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 340 -210 0 1 {name=M5
+L='2'
+W='1'
+nf=1
+mult=26.95
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 230 -60 0 1 {name=M6
+L=2
+W=1
+nf=1
+mult=3.65
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 90 -210 0 0 {name=M9
+L='2'
+W='1'
+nf=1
+mult=26.95
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/lab_pin.sym} 230 -340 1 0 {name=l2 lab=vg}
+C {devices/lab_pin.sym} 420 -140 1 0 {name=l12 lab=Vx}
+C {devices/lab_pin.sym} 210 -110 0 0 {name=l18 lab=Vq}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 400 -60 0 0 {name=M7
+L=2
+W=1
+nf=1
+mult=3.65
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 400 -290 0 0 {name=M13
+L=2
+W=1
+nf=1
+mult=77.32
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/ngspice_probe.sym} 420 -110 0 0 {name=r3}
+C {devices/ngspice_probe.sym} 210 -130 0 0 {name=r4}
+C {devices/ngspice_probe.sym} 170 -340 0 0 {name=r6}
+C {devices/ngspice_get_value.sym} 420 -230 0 0 {name=r16 node=i(@m.xm13.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 210 -150 0 0 {name=r17 node=i(@m.xm6.msky130_fd_pr__nfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 110 -240 0 0 {name=r18 node=i(@m.xm8.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 320 -240 0 1 {name=r19 node=i(@m.xm4.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 110 -280 0 0 {name=r10 node=@m.xm8.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 320 -280 0 1 {name=r11 node=@m.$\{path\}xm4.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 110 -150 0 0 {name=r12 node=@m.xm9.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 320 -150 0 1 {name=r13 node=@m.xm5.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 440 -220 0 0 {name=r14 node=@m.xm13.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 230 -90 0 0 {name=r15 node=@m.xm6.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 400 -90 0 1 {name=r23 node=@m.xm7.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_probe.sym} 320 -270 0 0 {name=r27}
+C {devices/gnd.sym} 210 -210 0 0 {name=l14 lab=GND}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 130 -340 0 1 {name=M4
+L=2
+W=1
+nf=1
+mult=38.66
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 300 -340 0 0 {name=M8
+L=2
+W=1
+nf=1
+mult=38.66
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/gnd.sym} 290 -30 0 0 {name=l17 lab=GND}
+C {devices/ipin.sym} 570 -190 2 0 {name=p1 lab=va}
+C {devices/ipin.sym} 570 -170 2 0 {name=p2 lab=vb}
+C {devices/opin.sym} 570 -150 0 0 {name=p3 lab=vout}
+C {devices/lab_pin.sym} 50 -210 0 0 {name=l1 lab=va}
+C {devices/lab_pin.sym} 370 -210 2 0 {name=l3 lab=vb}
+C {devices/lab_pin.sym} 520 -300 2 0 {name=l4 lab=vout}
+C {devices/vdd.sym} 270 -390 0 0 {name=l5 lab=VDD}

--- a/bandgap_sky130_v1/cascode_amplifier_with_bias-ckt.sym
+++ b/bandgap_sky130_v1/cascode_amplifier_with_bias-ckt.sym
@@ -1,0 +1,22 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
+}
+V {}
+S {}
+E {}
+L 4 -100 -30 -80 -30 {}
+L 4 -100 30 -80 30 {}
+B 5 -102.5 -32.5 -97.5 -27.5 {name=va dir=in }
+B 5 -102.5 27.5 -97.5 32.5 {name=vb dir=in }
+B 5 147.5 -2.5 152.5 2.5 {name=vout dir=out }
+P 4 4 -80 -60 -80 60 120 -0 -80 -60 {}
+P 4 2 120 0 150 0 {}
+T {@symname} -110 74 0 0 0.3 0.3 {}
+T {@name} 135 -32 0 0 0.2 0.2 {}
+T {va} -75 -34 0 0 0.2 0.2 {}
+T {vb} -75 26 0 0 0.2 0.2 {}
+T {vout} 85 -4 0 1 0.2 0.2 {}

--- a/bandgap_sky130_v1/cascode_bandgapCore.sch
+++ b/bandgap_sky130_v1/cascode_bandgapCore.sch
@@ -1,0 +1,108 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {}
+V {}
+S {}
+E {}
+P 4 5 870 -300 970 -300 970 -160 870 -160 870 -300 {}
+T {IO Pins} 890 -280 0 0 0.4 0.4 {}
+N 440 -380 570 -380 { lab=Vb}
+N 220 -90 220 -60 { lab=GND}
+N 160 -120 220 -120 { lab=GND}
+N 160 -120 160 -60 { lab=GND}
+N 440 -380 440 -360 { lab=Vb}
+N 440 -300 440 -280 { lab=#net1}
+N 570 -380 570 -360 { lab=Vb}
+N 570 -300 570 -280 { lab=#net2}
+N 90 -380 90 -360 { lab=Va}
+N 90 -300 90 -280 { lab=#net3}
+N 440 -220 440 -150 { lab=vbneg}
+N 90 -200 90 -60 { lab=GND}
+N 570 -190 570 -60 { lab=GND}
+N 480 -120 480 -60 { lab=GND}
+N 440 -90 440 -60 { lab=GND}
+N 400 -120 440 -120 { lab=GND}
+N 400 -120 400 -60 { lab=GND}
+N 260 -120 280 -120 { lab=GND}
+N 280 -120 280 -60 { lab=GND}
+N 70 -250 70 -200 { lab=GND}
+N 70 -200 90 -200 { lab=GND}
+N 550 -250 550 -190 { lab=GND}
+N 550 -190 570 -190 { lab=GND}
+N 340 -250 420 -250 { lab=GND}
+N 340 -250 340 -60 { lab=GND}
+N 220 -300 220 -150 { lab=Veb}
+N 330 -380 440 -380 { lab=Vb}
+N 220 -380 220 -360 { lab=Va}
+N 220 -380 290 -380 { lab=Va}
+N 90 -380 220 -380 { lab=Va}
+N 160 -60 220 -60 { lab=GND}
+N 90 -60 160 -60 { lab=GND}
+N 480 -60 570 -60 { lab=GND}
+N 440 -60 480 -60 { lab=GND}
+N 400 -60 440 -60 { lab=GND}
+N 340 -60 400 -60 { lab=GND}
+N 220 -60 280 -60 { lab=GND}
+N 90 -220 90 -200 { lab=GND}
+N 570 -220 570 -190 { lab=GND}
+N 280 -60 340 -60 { lab=GND}
+N 570 -60 740 -60 {
+lab=GND}
+N 740 -220 740 -60 {
+lab=GND}
+N 720 -250 720 -190 {
+lab=GND}
+N 720 -190 740 -190 {
+lab=GND}
+N 740 -380 740 -280 {
+lab=vbg}
+C {sky130_fd_pr/pnp_05v5.sym} 240 -120 0 1 {name=Q2
+model=pnp_05v5_W3p40L3p40
+spiceprefix=X
+}
+C {devices/gnd.sym} 250 -60 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 290 -380 3 0 {name=l5 lab=Va}
+C {devices/lab_pin.sym} 330 -380 3 0 {name=l6 lab=Vb}
+C {devices/ammeter.sym} 570 -330 0 0 {name=Vr4 current=5.7238e-06}
+C {devices/ammeter.sym} 440 -330 0 0 {name=Vr2 current=4.3334e-06}
+C {devices/ammeter.sym} 90 -330 0 0 {name=Vr1 current=5.7228e-06}
+C {devices/ammeter.sym} 220 -330 0 0 {name=Vq2 current=4.3346e-06}
+C {sky130_fd_pr/pnp_05v5.sym} 460 -120 0 1 {name=Q1
+model="pnp_05v5_W3p40L3p40 m=39"
+spiceprefix=X
+}
+C {devices/lab_pin.sym} 440 -190 0 0 {name=l4 lab=vbneg}
+C {devices/lab_pin.sym} 220 -270 2 0 {name=l10 lab=Veb}
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 90 -250 0 0 {name=R1
+W=0.35
+L=21.839
+model=res_xhigh_po_0p35
+spiceprefix=X
+mult=1}
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 570 -250 0 0 {name=R2
+W=0.35
+L=21.839
+model=res_xhigh_po_0p35
+spiceprefix=X
+mult=1}
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 440 -250 0 0 {name=R3
+W=0.35
+L=3.763
+model=res_xhigh_po_0p35
+spiceprefix=X
+mult=1}
+C {devices/ngspice_probe.sym} 220 -380 0 0 {name=r4}
+C {devices/ngspice_probe.sym} 440 -380 0 0 {name=r5}
+C {devices/ngspice_probe.sym} 440 -190 0 0 {name=r9}
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 740 -250 0 0 {name=R6
+W=0.35
+L=17.38
+model=res_xhigh_po_0p35
+spiceprefix=X
+mult=1}
+C {devices/lab_pin.sym} 740 -380 0 0 {name=l2 lab=vbg}
+C {devices/ngspice_probe.sym} 740 -320 0 0 {name=r8}
+C {devices/ipin.sym} 940 -240 0 0 {name=p1 lab=Va}
+C {devices/ipin.sym} 940 -220 0 0 {name=p2 lab=Vb}
+C {devices/iopin.sym} 940 -200 2 0 {name=p3 lab=vbg}

--- a/bandgap_sky130_v1/cascode_bandgapCore.sym
+++ b/bandgap_sky130_v1/cascode_bandgapCore.sym
@@ -1,0 +1,25 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
+}
+V {}
+S {}
+E {}
+L 4 -130 -20 130 -20 {}
+L 4 -130 20 130 20 {}
+L 4 -130 -20 -130 20 {}
+L 4 130 -20 130 20 {}
+L 4 -150 -10 -130 -10 {}
+L 4 -150 10 -130 10 {}
+L 7 130 -10 150 -10 {}
+B 5 -152.5 -12.5 -147.5 -7.5 {name=Va dir=in }
+B 5 -152.5 7.5 -147.5 12.5 {name=Vb dir=in }
+B 5 147.5 -12.5 152.5 -7.5 {name=vbg dir=inout }
+T {@symname} -67.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -32 0 0 0.2 0.2 {}
+T {Va} -125 -14 0 0 0.2 0.2 {}
+T {Vb} -125 6 0 0 0.2 0.2 {}
+T {vbg} 125 -14 0 1 0.2 0.2 {}

--- a/bandgap_sky130_v1/cascode_bandgap_real_op.sch
+++ b/bandgap_sky130_v1/cascode_bandgap_real_op.sch
@@ -1,0 +1,224 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {}
+V {}
+S {}
+E {}
+P 4 5 1000 -320 1420 -320 1420 -100 1000 -100 1000 -320 {}
+T {Voltages} 1020 -300 0 0 0.4 0.4 {}
+N 320 -80 340 -80 {
+lab=#net1}
+N 320 -120 320 -80 {
+lab=#net1}
+N 320 -170 340 -170 {
+lab=#net1}
+N 300 -230 340 -230 {
+lab=#net2}
+N 300 -60 340 -60 {
+lab=#net2}
+N 300 -230 300 -60 {
+lab=#net2}
+N 280 -120 320 -120 {
+lab=#net1}
+N 320 -170 320 -120 {
+lab=#net1}
+N 680 -250 680 -240 {
+lab=VDD}
+N 680 -340 770 -340 {
+lab=VDD}
+N 770 -250 770 -240 {
+lab=VDD}
+N 770 -170 790 -170 {
+lab=GND}
+N 770 -170 770 -140 {
+lab=GND}
+N 770 -140 790 -140 {
+lab=GND}
+N 790 -140 790 -120 {
+lab=GND}
+N 790 -260 790 -200 {
+lab=#net3}
+N 590 -200 790 -200 {
+lab=#net3}
+N 790 -340 790 -320 {
+lab=VDD}
+N 770 -340 790 -340 {
+lab=VDD}
+N 790 -340 900 -340 {
+lab=VDD}
+N 900 -340 900 -230 {
+lab=VDD}
+N 790 -200 860 -200 {
+lab=#net3}
+N 900 -200 910 -200 {
+lab=VDD}
+N 910 -230 910 -200 {
+lab=VDD}
+N 900 -230 910 -230 {
+lab=VDD}
+N 740 -250 740 -240 {
+lab=VDD}
+N 740 -250 770 -250 {
+lab=VDD}
+N 770 -340 770 -250 {
+lab=VDD}
+N 650 -250 650 -240 {
+lab=VDD}
+N 650 -250 680 -250 {
+lab=VDD}
+N 680 -340 680 -250 {
+lab=VDD}
+N 620 -280 620 -240 {
+lab=#net4}
+N 500 -280 620 -280 {
+lab=#net4}
+N 300 -280 440 -280 {
+lab=#net2}
+N 300 -280 300 -230 {
+lab=#net2}
+N 500 -320 710 -320 {
+lab=#net5}
+N 280 -320 440 -320 {
+lab=#net1}
+N 900 -170 900 -140 {
+lab=#net6}
+N 710 -320 710 -240 {
+lab=#net5}
+N 280 -320 280 -120 {
+lab=#net1}
+N 640 -80 900 -80 {
+lab=#net7}
+C {devices/vsource.sym} 1030 -200 0 0 {name=V1 net_name=true value="'VDD' pwl 0us 0 5us 'VDD'"}
+C {devices/vdd.sym} 1030 -230 0 0 {name=l8 lab=VDD}
+C {devices/gnd.sym} 1030 -170 0 0 {name=l9 lab=GND}
+C {devices/vsource.sym} 1210 -200 0 0 {name=V2 net_name=true value="0 pulse(0V 1.8V 10us 0us 0us 5us)"}
+C {devices/gnd.sym} 1210 -170 0 0 {name=l16 lab=GND}
+C {devices/lab_pin.sym} 1210 -230 0 0 {name=l19 lab=pin}
+C {devices/code.sym} 40 -320 0 0 {name=NGSPICE1
+only_toplevel=true
+spice_ignore=true
+value=".option seed=13
+
+* this experimental option enables mos model bin 
+* selection based on W/NF instead of W
+.param ABSVAR=0.03
+.param VDDGAUSS=agauss(1.8, 'ABSVAR', 1)
+.param VDD=VCCGAUSS
+** variation parameters:
+.param sky130_fd_pr__nfet_01v8_lvt__vth0_slope_spectre='agauss(0, ABSVAR, 3)/sky130_fd_pr__nfet_01v8_lvt__vth0_slope'
+.param sky130_fd_pr__pfet_01v8_lvt__vth0_slope_spectre='agauss(0, ABSVAR, 3)/sky130_fd_pr__pfet_01v8_lvt__vth0_slope'
+.param sky130_fd_pr__nfet_01v8__vth0_slope_spectre='agauss(0, ABSVAR, 3)/sky130_fd_pr__nfet_01v8__vth0_slope'
+.param sky130_fd_pr__pfet_01v8__vth0_slope_spectre='agauss(0, ABSVAR, 3)/sky130_fd_pr__pfet_01v8__vth0_slope'
+
+.param sky130_fd_pr__pfet_01v8__toxe_slope_spectre='agauss(0, ABSVAR*2, 3)/sky130_fd_pr__pfet_01v8__toxe_slope'
+.param sky130_fd_pr__nfet_01v8__toxe_slope_spectre='agauss(0, ABSVAR*2, 3)/sky130_fd_pr__nfet_01v8__toxe_slope'
+.param sky130_fd_pr__pfet_01v8_lvt__toxe_slope_spectre='agauss(0, ABSVAR*2, 3)/sky130_fd_pr__pfet_01v8_lvt__toxe_slope'
+.param sky130_fd_pr__nfet_01v8_lvt__toxe_slope_spectre='agauss(0, ABSVAR*2, 3)/sky130_fd_pr__nfet_01v8_lvt__toxe_slope'
+
+.param sky130_fd_pr__res_high_po__var_mult=agauss(0, 'ABSVAR*8', 1)
+
+* .options savecurrents
+.control
+  let run=1
+  dowhile run <= 40
+    if run > 1
+      reset
+      set appendwrite
+    end
+    save all
+    if run % 3 = 0
+      set temp=0
+    end
+    if run % 3 = 1
+      set temp=27
+    end
+    if run % 3 = 2
+      set temp=70
+    end
+    tran 0.05u 150u
+    write tsmc_bandgap_real_variation.raw
+    let run = run + 1
+  end
+  set nolegend
+  plot all.vbg
+.endc
+" }
+C {devices/code.sym} 40 -160 0 0 {name=TT_MODELS
+only_toplevel=true
+format="tcleval( @value )"
+value="
+** opencircuitdesign pdks install
+.lib $::SKYWATER_MODELS/sky130.lib.spice tt
+
+"
+spice_ignore=false}
+C {devices/vdd.sym} 770 -340 0 0 {name=l1 lab=VDD}
+C {devices/gnd.sym} 790 -120 0 0 {name=l2 lab=GND}
+C {devices/capa.sym} 790 -290 0 0 {name=C1
+m=1
+value=20p
+footprint=1206
+device="ceramic capacitor"}
+C {devices/lab_pin.sym} 830 -170 2 0 {name=l4 lab=pin}
+C {devices/ammeter.sym} 470 -280 1 0 {name=Vm1 current=1.0057e-05}
+C {devices/ammeter.sym} 470 -320 1 0 {name=Vm2 current=1.0057e-05}
+C {devices/ammeter.sym} 900 -110 0 0 {name=Vm3 current=1.0057e-05}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 650 -220 3 0 {name=M1
+L=2
+W=1
+nf=1
+mult=386.6
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 740 -220 3 0 {name=M2
+L=2
+W=1
+nf=1
+mult=386.6
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 880 -200 0 0 {name=M3
+L=2
+W=1
+nf=1
+mult=386.6
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 810 -170 2 0 {name=M10
+L='2'
+W='1'
+nf=1
+mult=34
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {/home/thomas/Projects/bandgapReferenceCircuit/bandgap_sky130_v1/cascode_amplifier_with_bias-ckt.sym} 440 -200 0 0 {name=x1}
+C {/home/thomas/Projects/bandgapReferenceCircuit/bandgap_sky130_v1/cascode_bandgapCore.sym} 490 -70 0 0 {name=x2}

--- a/bandgap_sky130_v1/untitled-1.sch
+++ b/bandgap_sky130_v1/untitled-1.sch
@@ -1,0 +1,201 @@
+v {xschem version=3.1.0 file_version=1.2
+}
+G {}
+K {}
+V {}
+S {}
+E {}
+P 4 5 520 -300 620 -300 620 -140 520 -140 520 -300 {}
+T {I/O Pins} 530 -290 0 0 0.4 0.4 {}
+N 120 -440 180 -440 { lab=vg}
+N 180 -470 180 -440 { lab=vg}
+N 160 -470 180 -470 { lab=vg}
+N 180 -470 290 -470 { lab=vg}
+N 120 -520 120 -500 { lab=VDD}
+N 330 -520 330 -500 { lab=VDD}
+N 120 -440 120 -370 { lab=vg}
+N 330 -430 330 -370 { lab=VOUT}
+N 320 -310 330 -310 { lab=Vq}
+N 330 -470 340 -470 { lab=VDD}
+N 340 -500 340 -470 { lab=VDD}
+N 330 -500 340 -500 { lab=VDD}
+N 110 -470 120 -470 { lab=VDD}
+N 110 -500 110 -470 { lab=VDD}
+N 110 -500 120 -500 { lab=VDD}
+N 120 -340 130 -340 { lab=VSS}
+N 320 -340 330 -340 { lab=VSS}
+N 210 -190 220 -190 { lab=VSS}
+N 210 -190 210 -160 { lab=VSS}
+N 260 -190 390 -190 { lab=Vx}
+N 430 -190 440 -190 { lab=VSS}
+N 390 -220 390 -190 { lab=Vx}
+N 390 -220 430 -220 { lab=Vx}
+N 440 -190 440 -160 { lab=VSS}
+N 430 -420 440 -420 { lab=VDD}
+N 440 -450 440 -420 { lab=VDD}
+N 430 -450 440 -450 { lab=VDD}
+N 220 -310 220 -220 { lab=Vq}
+N 390 -430 390 -420 { lab=VOUT}
+N 430 -520 430 -450 { lab=VDD}
+N 430 -220 430 -200 { lab=Vx}
+N 120 -520 330 -520 { lab=VDD}
+N 120 -310 130 -310 { lab=Vq}
+N 220 -310 320 -310 { lab=Vq}
+N 210 -160 440 -160 { lab=VSS}
+N 430 -390 430 -200 { lab=Vx}
+N 130 -310 220 -310 { lab=Vq}
+N 330 -440 330 -430 { lab=VOUT}
+N 330 -430 390 -430 { lab=VOUT}
+N 330 -520 430 -520 { lab=VDD}
+N 130 -340 320 -340 { lab=VSS}
+N 370 -340 380 -340 {
+lab=VIN-}
+N 70 -340 80 -340 {
+lab=VIN+}
+N 390 -430 520 -430 {
+lab=VOUT}
+N 330 -160 330 -130 {
+lab=VSS}
+N 240 -560 240 -520 {
+lab=VDD}
+N 220 -380 220 -340 {
+lab=VSS}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 350 -340 0 1 {name=M5
+L='2'
+W='1'
+nf=1
+mult=26.95
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 240 -190 0 1 {name=M6
+L=2
+W=1
+nf=1
+mult=3.65
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 100 -340 0 0 {name=M9
+L='2'
+W='1'
+nf=1
+mult=26.95
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/lab_pin.sym} 240 -470 1 0 {name=l2 lab=vg}
+C {devices/lab_pin.sym} 430 -200 1 0 {name=l12 lab=Vx}
+C {devices/lab_pin.sym} 220 -250 0 0 {name=l18 lab=Vq}
+C {sky130_fd_pr/nfet_01v8_lvt.sym} 410 -190 0 0 {name=M7
+L=2
+W=1
+nf=1
+mult=3.65
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=nfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 410 -420 0 0 {name=M13
+L=2
+W=1
+nf=1
+mult=77.32
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/ngspice_probe.sym} 430 -170 0 0 {name=r3}
+C {devices/ngspice_probe.sym} 220 -260 0 0 {name=r4}
+C {devices/ngspice_probe.sym} 180 -470 0 0 {name=r6}
+C {devices/ngspice_get_value.sym} 430 -290 0 0 {name=r16 node=i(@m.xm13.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 220 -240 0 0 {name=r17 node=i(@m.xm6.msky130_fd_pr__nfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 120 -370 0 0 {name=r18 node=i(@m.xm8.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 330 -370 0 1 {name=r19 node=i(@m.xm4.msky130_fd_pr__pfet_01v8_lvt[id])
+descr="I="}
+C {devices/ngspice_get_value.sym} 120 -410 0 0 {name=r10 node=@m.xm8.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 330 -410 0 1 {name=r11 node=@m.$\{path\}xm4.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 120 -280 0 0 {name=r12 node=@m.xm9.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 330 -280 0 1 {name=r13 node=@m.xm5.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 450 -350 0 0 {name=r14 node=@m.xm13.msky130_fd_pr__pfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 240 -220 0 0 {name=r15 node=@m.xm6.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_get_value.sym} 410 -220 0 1 {name=r23 node=@m.xm7.msky130_fd_pr__nfet_01v8_lvt[gm]
+descr="gm="}
+C {devices/ngspice_probe.sym} 330 -400 0 0 {name=r27}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 140 -470 0 1 {name=M4
+L=2
+W=1
+nf=1
+mult=38.66
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 310 -470 0 0 {name=M8
+L=2
+W=1
+nf=1
+mult=38.66
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/title.sym} 170 -40 0 0 {name=l1 author="Cascode Labs"}
+C {devices/opin.sym} 540 -250 0 0 {name=p1 lab=VOUT}
+C {devices/ipin.sym} 540 -230 2 0 {name=p2 lab=VIN+}
+C {devices/ipin.sym} 540 -210 2 0 {name=p3 lab=VIN-}
+C {devices/ipin.sym} 540 -190 2 0 {name=p4 lab=VDD}
+C {devices/ipin.sym} 540 -170 2 0 {name=p5 lab=VSS}
+C {devices/lab_pin.sym} 70 -340 0 0 {name=p6 sig_type=std_logic lab=VIN+}
+C {devices/lab_pin.sym} 380 -340 2 0 {name=p7 sig_type=std_logic lab=VIN-}
+C {devices/lab_pin.sym} 240 -560 1 0 {name=p8 sig_type=std_logic lab=VDD}
+C {devices/lab_pin.sym} 330 -130 3 0 {name=p9 sig_type=std_logic lab=VSS}
+C {devices/lab_pin.sym} 220 -380 1 0 {name=p10 sig_type=std_logic lab=VSS}
+C {devices/lab_pin.sym} 520 -430 2 0 {name=p11 sig_type=std_logic lab=VOUT}


### PR DESCRIPTION
## Description

Deconstructed `tscm_bandgap_real_op.sch` into two additional schematics with symbols:

- `cascode_amplifier_with_bias-ckt.sch` Which has the OTA with Bias component with parameters taken from original bandgap.
- `cascode_bandgapCore.sch` the Bandgap Reference core with parameters taken directly from original bandgap.

## How Has This Been Tested?

Successful netlisting 
